### PR TITLE
Fix build warning in atom.xml

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">


### PR DESCRIPTION
`Build Warning: Layout 'nil' requested in atom.xml does not exist.`
see: https://github.com/jekyll/jekyll/issues/2712#issuecomment-51614932
